### PR TITLE
Fix links being badly handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ MIT
 [//]: # (These are reference links used in the body of this note and get stripped out when the markdown processor does its job. There is no need to format nicely because it shouldn't be seen. Thanks SO - http://stackoverflow.com/questions/4823468/store-comments-in-markdown-syntax)
 
 
-   [mux]: <github.com/gorilla/mux>
-   [autocert]: <golang.org/x/crypto/acme/autocert>
-   [skv]: <github.com/rapidloop/skv>
+   [mux]: <https://github.com/gorilla/mux>
+   [autocert]: <https://golang.org/x/crypto/acme/autocert>
+   [skv]: <https://github.com/rapidloop/skv>


### PR DESCRIPTION
The links in the README.md were redirecting to https://github.com/AmIJesse/Anonish-URL-shortener/blob/master/github.com/gorilla/mux instead of https://github.com/gorilla/mux for example.